### PR TITLE
MacOS and Linux flags using new `flag` statement.

### DIFF
--- a/ldpl-ncurses/ldpl-ncurses.ldpl
+++ b/ldpl-ncurses/ldpl-ncurses.ldpl
@@ -1,5 +1,7 @@
 extension "ldpl-ncurses.cpp"
-flag "-lncursesw"
+flag linux "-lncursesw"
+flag macos "-lncurses"
+flag macos "-D_XOPEN_SOURCE_EXTENDED"
 
 data:
 NCURSES_LDPLLIB_COLOR is external number


### PR DESCRIPTION
This uses the new `flag` statement in 4.4-dev so you probably don't want to merge until it's released. 